### PR TITLE
Add command line arguments to the socketserverREPL.

### DIFF
--- a/repl_tool.py
+++ b/repl_tool.py
@@ -307,7 +307,8 @@ def run_repl(args):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description="A helper script to interact"
+                                     " with a Python REPL exposed over tcp")
     parser.add_argument('-d', '--dest', default=None,
                         help="Hostname or ip of target running REPL. Defaults"
                         " to 127.0.0.1, will use environment value of "


### PR DESCRIPTION
This adds command line arguments to the `socketserverREPL.py` script. Including an option to close when interrupted even if there are active connections to the server.